### PR TITLE
feat: prioritize todayItemStyle over activeItemStyle

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -208,6 +208,7 @@ export default function App() {
               // eslint-disable-next-line react-native/no-inline-styles
               todayContainerStyle={{
                 borderWidth: 1,
+                borderColor: '#999',
               }}
             />
             <View style={styles.footer}>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -208,7 +208,6 @@ export default function App() {
               // eslint-disable-next-line react-native/no-inline-styles
               todayContainerStyle={{
                 borderWidth: 1,
-                borderColor: '#999',
               }}
             />
             <View style={styles.footer}>

--- a/src/components/Day.tsx
+++ b/src/components/Day.tsx
@@ -123,8 +123,8 @@ function Day({
         style={[
           style.dayContainer,
           containerStyle,
-          todayItemStyle,
           activeItemStyle,
+          todayItemStyle,
           disabled && style.disabledDay,
         ]}
         testID={date}


### PR DESCRIPTION
This change ensures todayItemStyle is always applied, even when the current day is selected, to maintain a visual distinction between today and selected days.

[Preview](https://drive.google.com/file/d/1tnfN2I_5hzTQc3yy7qxQ1m77TKrrjSJe/view?usp=drive_link)
