### PR TITLE
feat: add style property for default calendar day item

### DIFF
--- a/src/components/Day.tsx
+++ b/src/components/Day.tsx
@@ -41,6 +41,7 @@ function Day({
   }, [onSelectDate, date]);
 
   const {
+    calendarItemStyle,
     calendarTextStyle,
     dayContainerStyle,
     selectedItemColor,
@@ -68,7 +69,9 @@ function Day({
         borderColor: selectedItemColor || '#0047FF',
         backgroundColor: selectedItemColor || '#0047FF',
       }
-    : null;
+    : disabled
+    ? null
+    : calendarItemStyle;
 
   const textStyle = isSelected
     ? { color: '#fff', ...selectedTextStyle }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export type CalendarThemeProps = {
   weekDaysContainerStyle?: ViewStyle;
   weekDaysTextStyle?: TextStyle;
   calendarTextStyle?: TextStyle;
+  calendarItemStyle?: ViewStyle;
   selectedTextStyle?: TextStyle;
   selectedItemColor?: string;
   timePickerContainerStyle?: ViewStyle;


### PR DESCRIPTION
A style prop that allows users to define a custom item style for unselected and enabled days.

[Preview](https://drive.google.com/file/d/1_Q5GQ3ELYtIfGTIXAo3yN9LqUDvjF4Jb/view?usp=drive_link)